### PR TITLE
jQuery changes to work with CiviCRM 4.4.6 class names

### DIFF
--- a/templates/CRM/Event/Form/Registration/Register.extra.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.extra.tpl
@@ -6,7 +6,7 @@ cj(this).after(' <div class = "crm-section"><div class ="label" >{/literal}{$for
 }
 }); */
 if (cj('#is_share').length == 0 ) {
-cj('.first_name2-section').before(' <div class = "crm-section"><div class ="label" >{/literal}{$form.is_spouse.label}{literal}</div><div class ="content" id = "is_spouse" >{/literal}{$form.is_spouse.html}{literal}</div><div class="clear"></div></div><div class = "crm-section"><div class ="label" >{/literal}{$form.is_shareAdd.label}{literal}</div><div class ="content" id = "is_share">{/literal}{$form.is_shareAdd.html}{literal}</div><div class="clear"></div></div>');
+cj('.editrow_first_name2-section').before(' <div class = "crm-section"><div class ="label" >{/literal}{$form.is_spouse.label}{literal}</div><div class ="content" id = "is_spouse" >{/literal}{$form.is_spouse.html}{literal}</div><div class="clear"></div></div><div class = "crm-section"><div class ="label" >{/literal}{$form.is_shareAdd.label}{literal}</div><div class ="content" id = "is_share">{/literal}{$form.is_shareAdd.html}{literal}</div><div class="clear"></div></div>');
 }
 
 cj(document).ready(function() {
@@ -18,10 +18,10 @@ cj('#email-5').val('');
 cj('#is_share input:radio').each( function() {
 if ( cj(this).is(':checked') ) {
    if( cj(this).val() == 1 ) {
-    cj(".street_address-Primary2-section").hide();
-    cj(".city-Primary2-section").hide();
-    cj(".state_province-Primary2-section").hide();
-    cj(".postal_code-Primary2-section").hide();
+    cj(".editrow_street_address-Primary2-section").hide();
+    cj(".editrow_city-Primary2-section").hide();
+    cj(".editrow_state_province-Primary2-section").hide();
+    cj(".editrow_postal_code-Primary2-section").hide();
    }
 }
 });	
@@ -29,23 +29,23 @@ if ( cj(this).is(':checked') ) {
 });
 cj('#is_share input').click( function() {
 if ( cj(this).val() == 1 ) {
-  cj("#street_address-Primary2").val(cj('#street_address-Primary1').val());
-  cj("#city-Primary2").val(cj('#city-Primary1').val());
-  cj("#state_province-Primary2").val(cj('#state_province-Primary1').val());
-  cj("#postal_code-Primary2").val(cj('#postal_code-Primary1').val());
-  cj(".street_address-Primary2-section").hide();
-  cj(".city-Primary2-section").hide();
-  cj(".state_province-Primary2-section").hide();
-  cj(".postal_code-Primary2-section").hide();
+  cj("#editrow-street_address-Primary2").val(cj('#editrow-street_address-Primary1').val());
+  cj("#editrow-city-Primary2").val(cj('#editrow-city-Primary1').val());
+  cj("#editrow-state_province-Primary2").val(cj('#editrow-state_province-Primary1').val());
+  cj("#editrow-postal_code-Primary2").val(cj('#editrow-postal_code-Primary1').val());
+  cj(".editrow_street_address-Primary2-section").hide();
+  cj(".editrow_city-Primary2-section").hide();
+  cj(".editrow_state_province-Primary2-section").hide();
+  cj(".editrow_postal_code-Primary2-section").hide();
 } else {
-  cj("#street_address-Primary2").val('');
-  cj("#city-Primary2").val('');
-  cj("#state_province-Primary2").val('');
-  cj("#postal_code-Primary2").val('');
-  cj(".street_address-Primary2-section").show();
-  cj(".city-Primary2-section").show();
-  cj(".state_province-Primary2-section").show();
-  cj(".postal_code-Primary2-section").show();
+  cj("#editrow-street_address-Primary2").val('');
+  cj("#editrow-city-Primary2").val('');
+  cj("#editrow-state_province-Primary2").val('');
+  cj("#editrow-postal_code-Primary2").val('');
+  cj(".editrow_street_address-Primary2-section").show();
+  cj(".editrow_city-Primary2-section").show();
+  cj(".editrow_state_province-Primary2-section").show();
+  cj(".editrow_postal_code-Primary2-section").show();
 }
 });
 


### PR DESCRIPTION
Hi Sarah
The template changes here match the class names used in CiviCRM 4.4.6 (prepending "editrow") so jQuery works again.  

Aidan
